### PR TITLE
Fixed PHP 8.0 call to undefined function

### DIFF
--- a/songkick_widget.php
+++ b/songkick_widget.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action('widgets_init', create_function( '', 'return register_widget("SongkickConcertsWidget");'));
+add_action('widgets_init', function( ) { return register_widget( "SongkickConcertsWidget" ); } );
 
 class SongkickConcertsWidget extends WP_Widget {
 


### PR DESCRIPTION
create_function() was deprecated in PHP 7.0 and has been REMOVED as of PHP 8.0.

I replaced create_function() with an anonymous function, for comptability with PHP 8.0.